### PR TITLE
Add support for DatedServiceJourney

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Support for DatedServiceJourney
+
 ### Fixed
 - Improved detection of changes in imported data.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Support for DatedServiceJourney
+- Support for DatedServiceJourney.
 
 ### Fixed
 - Improved detection of changes in imported data.

--- a/database/migrations/2024_09_10_142353_netex_dated_service_journey.php
+++ b/database/migrations/2024_09_10_142353_netex_dated_service_journey.php
@@ -20,7 +20,7 @@ return new class extends Migration
 
         Schema::create('netex_dated_service_journeys', function (Blueprint $table) {
             $table->char('id')->primary()->comment('Neted ID of dated service journey');
-            $table->char('service_journey_ref')->comment('Relation to netex_vehicle_journeys.id');
+            $table->char('service_journey_ref')->index()->comment('Relation to netex_vehicle_journeys.id');
             $table->char('operating_day_ref')->comment('Relation to nextex_operating_days.id');
         });
 

--- a/database/migrations/2024_09_10_142353_netex_dated_service_journey.php
+++ b/database/migrations/2024_09_10_142353_netex_dated_service_journey.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('netex_operating_days', function (Blueprint $table) {
+            $table->char('id')->primary()->comment("Netex ID of operating day");
+            $table->date('calendar_date')->comment('Calendar date of day in ISO format');
+        });
+
+        Schema::create('netex_dated_service_journeys', function (Blueprint $table) {
+            $table->char('id')->primary()->comment('Neted ID of dated service journey');
+            $table->char('service_journey_ref')->comment('Relation to netex_vehicle_journeys.id');
+            $table->char('operating_day_ref')->comment('Relation to nextex_operating_days.id');
+        });
+
+        Schema::table('netex_vehicle_journeys', function (Blueprint $table) {
+            $table->char('calendar_ref')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('netex_operating_days');
+        Schema::dropIfExists('netex_dated_service_journeys');
+    }
+};

--- a/src/Services/RouteBase.php
+++ b/src/Services/RouteBase.php
@@ -2,6 +2,7 @@
 
 namespace TromsFylkestrafikk\Netex\Services;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -104,7 +105,31 @@ class RouteBase
      *
      * @return Collection
      */
-    protected static function getRawJourneys(string $date)
+    protected static function getRawJourneys(string $date): Collection
+    {
+        return self::getRawDatedServiceJourneys($date)->merge(self::getRawCalendarJourneys($date));
+    }
+
+    protected static function getRawCalendarJourneys(string $date): Collection
+    {
+        return self::buildRawJourneysQuery($date)->whereIn(
+            'journey.calendar_ref',
+            function (\Illuminate\Database\Query\Builder $query) use ($date) {
+                $query->select('ref')->from('netex_calendar')->whereDate('date', '=', $date);
+            }
+        )->get();
+    }
+
+    protected static function getRawDatedServiceJourneys(string $date): Collection
+    {
+        return self::buildRawJourneysQuery($date)
+            ->join('netex_dated_service_journeys as dsj', 'dsj.service_journey_ref', '=', 'journey.id')
+            ->join('netex_operating_days as days', 'dsj.operating_day_ref', '=', 'days.id')
+            ->where('days.calendar_date', $date)
+            ->get();
+    }
+
+    protected static function buildRawJourneysQuery(string $date): Builder
     {
         return DB::table('netex_vehicle_journeys', 'journey')
             ->select([
@@ -124,12 +149,8 @@ class RouteBase
             ->join('netex_journey_patterns as pattern', 'journey.journey_pattern_ref', '=', 'pattern.id')
             ->join('netex_routes as route', 'pattern.route_ref', 'route.id')
             ->join('netex_lines as line', 'journey.line_ref', 'line.id')
-            ->whereIn('journey.calendar_ref', function (\Illuminate\Database\Query\Builder $query) use ($date) {
-                $query->select('ref')->from('netex_calendar')->whereDate('date', '=', $date);
-            })
             ->orderBy('line.private_code')
-            ->orderBy('journey.private_code')
-            ->get();
+            ->orderBy('journey.private_code');
     }
 
     /**

--- a/src/Services/RouteBase.php
+++ b/src/Services/RouteBase.php
@@ -114,7 +114,7 @@ class RouteBase
     {
         return self::buildRawJourneysQuery($date)->whereIn(
             'journey.calendar_ref',
-            function (\Illuminate\Database\Query\Builder $query) use ($date) {
+            function (Builder $query) use ($date) {
                 $query->select('ref')->from('netex_calendar')->whereDate('date', '=', $date);
             }
         )->get();

--- a/src/Services/RouteImporter.php
+++ b/src/Services/RouteImporter.php
@@ -30,12 +30,14 @@ class RouteImporter
         'netex_stop_assignments',
         'netex_destination_displays',
         'netex_service_links',
+        'netex_operating_days',
         'netex_vehicle_schedules',
         'netex_vehicle_blocks',
         'netex_notices',
 
         // Line data tables
         'netex_vehicle_journeys',
+        'netex_dated_service_journeys',
         'netex_passing_times',
         'netex_journey_patterns',
         'netex_journey_pattern_stop_point',

--- a/src/Services/RouteImporter/NetexLineImporter.php
+++ b/src/Services/RouteImporter/NetexLineImporter.php
@@ -28,6 +28,10 @@ class NetexLineImporter extends NetexImporterBase
             'path' => ['TimetableFrame', 'vehicleJourneys', 'ServiceJourney'],
             'table' => 'netex_vehicle_journeys',
         ],
+        'DatedServiceJourney' => [
+            'path' => ['TimetableFrame', 'vehicleJourneys', 'DatedServiceJourney'],
+            'table' => 'netex_dated_service_journeys',
+        ],
         'TimetabledPassingTime' => ['table' => 'netex_passing_times'],
         'NoticeAssignment' => [
             'path' => ['TimetableFrame', 'noticeAssignments', 'NoticeAssignment'],
@@ -93,7 +97,7 @@ class NetexLineImporter extends NetexImporterBase
         ];
     }
 
-    protected function readServiceJourney(SimpleXMLElement $xml): array
+    protected function readServiceJourney(SimpleXMLElement $xml): array|null
     {
         $journeyId = (string) $xml['id'];
 
@@ -113,7 +117,16 @@ class NetexLineImporter extends NetexImporterBase
             'journey_pattern_ref' => $xml->JourneyPatternRef['ref'],
             'operator_ref' => $xml->OperatorRef['ref'],
             'line_ref' => $xml->LineRef['ref'],
-            'calendar_ref' => $xml->dayTypes->DayTypeRef['ref'],
+            'calendar_ref' => isset($xml->dayTypes) ? $xml->dayTypes->DayTypeRef['ref'] : null,
+        ];
+    }
+
+    protected function readDatedServiceJourney(SimpleXMLElement $xml): array
+    {
+        return [
+            'id' => $xml['id'],
+            'service_journey_ref' => $xml->ServiceJourneyRef['ref'],
+            'operating_day_ref' => $xml->OperatingDayRef['ref'],
         ];
     }
 

--- a/src/Services/RouteImporter/NetexSharedImporter.php
+++ b/src/Services/RouteImporter/NetexSharedImporter.php
@@ -51,6 +51,10 @@ class NetexSharedImporter extends NetexImporterBase
         'BlockJourneyRef'   => ['table' => 'netex_vehicle_schedules'],
         'Calendar'          => ['table' => 'netex_calendar'],
         'DayType'           => ['path' => ['ServiceCalendarFrame', 'dayTypes', 'DayType']],
+        'OperatingDay'      => [
+            'path' => ['ServiceCalendarFrame', 'operatingDays', 'OperatingDay'],
+            'table' => 'netex_operating_days',
+        ],
         'OperatingPeriod'   => ['path' => ['ServiceCalendarFrame', 'operatingPeriods', 'OperatingPeriod']],
         'DayTypeAssignment' => ['path' => ['ServiceCalendarFrame', 'dayTypeAssignments', 'DayTypeAssignment']],
 
@@ -151,7 +155,15 @@ class NetexSharedImporter extends NetexImporterBase
         ];
     }
 
-    protected function readDayType(SimpleXMLElement $xml): null
+    protected function readOperatingDay(SimpleXMLElement $xml): array
+    {
+        return [
+            'id' => $xml['id'],
+            'calendar_date' => $xml->CalendarDate,
+        ];
+    }
+
+    protected function readDayType(SimpleXMLElement $xml): array|null
     {
         $id = (string) $xml['id'];
         $this->dayTypes[$id]['DaysOfWeek'] = isset($xml->properties)
@@ -160,7 +172,7 @@ class NetexSharedImporter extends NetexImporterBase
         return null;
     }
 
-    protected function readOperatingPeriod(SimpleXMLElement $xml): null
+    protected function readOperatingPeriod(SimpleXMLElement $xml): array|null
     {
         $id = (string) $xml['id'];
         $this->operatingPeriods[$id]['FromDate'] = $xml->FromDate;
@@ -168,7 +180,7 @@ class NetexSharedImporter extends NetexImporterBase
         return null;
     }
 
-    protected function readDayTypeAssignment(SimpleXMLElement $xml): null
+    protected function readDayTypeAssignment(SimpleXMLElement $xml): array|null
     {
         $id = (string) $xml['id'];
         $this->dayTypeAssignments[$id]['order'] = (int) $xml['order'];


### PR DESCRIPTION
What days ServiceJourneys are to be executed on now comes in two forms:
1. The old calendar style with weekday and date period mapping. The format is an intricate and somewhat complex relationship between weekday coding and calendar sets which have weekday mapping to periods, and journeys which refers to these calendar setups. It's really a mess, but this is what we've been using and will be using still for quite a while.
2. The new DatedServiceJourney style which maps ServiceJourney to a given date, i.e. a full rolled out list of dates a journey is scheduled. The structure is simple and easily understandable. It makes the whole process of rolling out days a breeze.

This PR adds support for 2.