### PR TITLE
Allow multivalue DayTypeRef on ServiceJourney

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- ServiceJourneys can have several DayTypeRef's.
+
 ## [0.3.0] – 2024-09-18
 
 ### Added

--- a/database/migrations/2024_10_11_140000_netex_multi_daytype.php
+++ b/database/migrations/2024_10_11_140000_netex_multi_daytype.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('netex_journey_day_types', function (Blueprint $table) {
+            $table->id()->comment('Laravel internal ID');
+            $table->char('service_journey_id')->index()->comment('References netex_vehicle_journey.id');
+            $table->char('day_type_ref')->comment('Daytype reference. This can be joined with `netex_calendar.ref` to retrieve dates.');
+        });
+
+        Schema::table('netex_vehicle_journeys', function (Blueprint $table) {
+            $table->dropColumn('calendar_ref');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('netex_journey_day_types');
+
+        Schema::table('netex_vehicle_journeys', function (Blueprint $table) {
+            $table->char('calendar_ref');
+        });
+    }
+};

--- a/src/Models/VehicleJourney.php
+++ b/src/Models/VehicleJourney.php
@@ -14,11 +14,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property string $journey_pattern_ref
  * @property int $operator_ref
  * @property string $line_ref
- * @property int $calendar_ref
  * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney query()
- * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney whereCalendarRef($value)
  * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney whereJourneyPatternRef($value)
  * @method static \Illuminate\Database\Eloquent\Builder|VehicleJourney whereLineRef($value)

--- a/src/Services/RouteBase.php
+++ b/src/Services/RouteBase.php
@@ -112,12 +112,11 @@ class RouteBase
 
     protected static function getRawCalendarJourneys(string $date): Collection
     {
-        return self::buildRawJourneysQuery($date)->whereIn(
-            'journey.calendar_ref',
-            function (Builder $query) use ($date) {
-                $query->select('ref')->from('netex_calendar')->whereDate('date', '=', $date);
-            }
-        )->get();
+        return self::buildRawJourneysQuery($date)
+            ->join('netex_journey_day_types as jdt', 'jdt.service_journey_id', '=', 'journey.id')
+            ->join('netex_calendar as cal', 'jdt.day_type_ref', '=', 'cal.ref')
+            ->whereDate('cal.date', '=', $date)
+            ->get();
     }
 
     protected static function getRawDatedServiceJourneys(string $date): Collection

--- a/src/Services/RouteImporter/NetexLineImporter.php
+++ b/src/Services/RouteImporter/NetexLineImporter.php
@@ -68,7 +68,7 @@ class NetexLineImporter extends NetexImporterBase
             'transport_mode' => $xml->TransportMode,
             'transport_submode' => $xml->TransportSubmode->children()[0],
             'public_code' => $xml->PublicCode,
-            'private_code' => $xml->PrivateCode,
+            'private_code' => $xml->PrivateCode ?: ((int) $xml->PublicCode),
             'operator_ref' => isset($xml->OperatorRef) ? $xml->OperatorRef['ref'] : null,
             'line_group_ref' => $xml->RepresentedByGroupRef['ref'],
         ];
@@ -92,13 +92,15 @@ class NetexLineImporter extends NetexImporterBase
             ]);
         }
 
-        foreach ($xml->linksInSequence->ServiceLinkInJourneyPattern as $link) {
-            $this->dumpers['JourneyPatternLinks']->addRecord([
-                'id' => $link['id'],
-                'journey_pattern_ref' => $jpId,
-                'order' => $link->attributes()->order,
-                'service_link_ref' => $link->ServiceLinkRef['ref'],
-            ]);
+        if ($xml->linksInSequence->ServiceLinkInJourneyPattern) {
+            foreach ($xml->linksInSequence->ServiceLinkInJourneyPattern as $link) {
+                $this->dumpers['JourneyPatternLinks']->addRecord([
+                    'id' => $link['id'],
+                    'journey_pattern_ref' => $jpId,
+                    'order' => $link->attributes()->order,
+                    'service_link_ref' => $link->ServiceLinkRef['ref'],
+                ]);
+            }
         }
 
         return [

--- a/src/Services/RouteImporter/NetexLineImporter.php
+++ b/src/Services/RouteImporter/NetexLineImporter.php
@@ -29,6 +29,7 @@ class NetexLineImporter extends NetexImporterBase
             'path' => ['TimetableFrame', 'vehicleJourneys', 'ServiceJourney'],
             'table' => 'netex_vehicle_journeys',
         ],
+        'JourneyDayType' => ['table' => 'netex_journey_day_types'],
         'DatedServiceJourney' => [
             'path' => ['TimetableFrame', 'vehicleJourneys', 'DatedServiceJourney'],
             'table' => 'netex_dated_service_journeys',
@@ -120,6 +121,15 @@ class NetexLineImporter extends NetexImporterBase
             ]);
         }
 
+        if (isset($xml->dayTypes)) {
+            foreach ($xml->dayTypes->DayTypeRef as $dayTypeRef) {
+                $this->dumpers['JourneyDayType']->addRecord([
+                    'service_journey_id' => $journeyId,
+                    'day_type_ref' => $dayTypeRef['ref'],
+                ]);
+            }
+        }
+
         return [
             'id' => $journeyId,
             'name' => $xml->Name,
@@ -127,7 +137,6 @@ class NetexLineImporter extends NetexImporterBase
             'journey_pattern_ref' => $xml->JourneyPatternRef['ref'],
             'operator_ref' => $xml->OperatorRef['ref'],
             'line_ref' => $xml->LineRef['ref'],
-            'calendar_ref' => isset($xml->dayTypes) ? $xml->dayTypes->DayTypeRef['ref'] : null,
         ];
     }
 

--- a/src/Services/RouteImporter/NetexLineImporter.php
+++ b/src/Services/RouteImporter/NetexLineImporter.php
@@ -68,7 +68,7 @@ class NetexLineImporter extends NetexImporterBase
             'transport_mode' => $xml->TransportMode,
             'transport_submode' => $xml->TransportSubmode->children()[0],
             'public_code' => $xml->PublicCode,
-            'private_code' => $xml->PrivateCode ?: ((int) $xml->PublicCode),
+            'private_code' => $xml->PrivateCode,
             'operator_ref' => isset($xml->OperatorRef) ? $xml->OperatorRef['ref'] : null,
             'line_group_ref' => $xml->RepresentedByGroupRef['ref'],
         ];
@@ -92,15 +92,13 @@ class NetexLineImporter extends NetexImporterBase
             ]);
         }
 
-        if ($xml->linksInSequence->ServiceLinkInJourneyPattern) {
-            foreach ($xml->linksInSequence->ServiceLinkInJourneyPattern as $link) {
-                $this->dumpers['JourneyPatternLinks']->addRecord([
-                    'id' => $link['id'],
-                    'journey_pattern_ref' => $jpId,
-                    'order' => $link->attributes()->order,
-                    'service_link_ref' => $link->ServiceLinkRef['ref'],
-                ]);
-            }
+        foreach ($xml->linksInSequence->ServiceLinkInJourneyPattern as $link) {
+            $this->dumpers['JourneyPatternLinks']->addRecord([
+                'id' => $link['id'],
+                'journey_pattern_ref' => $jpId,
+                'order' => $link->attributes()->order,
+                'service_link_ref' => $link->ServiceLinkRef['ref'],
+            ]);
         }
 
         return [


### PR DESCRIPTION
Møre og Romsdal utilizes Daytype and calendar management differently, and still in line with the NeTEx standard. This allows `ServiceJourney`s to have 1:N mapping with `DayType`.