### PR TITLE
fix: Flush `netex_calendar` after import of shared data file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - ServiceJourneys can have several DayTypeRef's.
+- `netex_calendar` is properly flushed after import.
 
 ## [0.3.0] – 2024-09-18
 

--- a/src/Services/RouteImporter/NetexSharedImporter.php
+++ b/src/Services/RouteImporter/NetexSharedImporter.php
@@ -233,6 +233,7 @@ class NetexSharedImporter extends NetexImporterBase
                 ]);
             }
         }
+        $this->dumpers['Calendar']->flush();
     }
 
     /**


### PR DESCRIPTION
Yup. The calendar is flushed when the php process dies, but not during execution. The problem arised when calling several artisan commands in succession (`netex:routedata-import` and `netex:routedata-activate`). Between import and activate the calendar table wasn't flushed properly, but it *is* flushed when the entire artisan command is finished.