### PR TITLE
change: active calls table now contains `line_public_code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,83 +1,107 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- The `netex_active_calls.line_private_code` column has been replaced with
+  `netex_active_calls.line_private_code` due to `private` code beeing optional in NeTEx
+
 ## [0.3.1] – 2024-08-18
+
 ### Fixed
+
 - ServiceJourneys can have several DayTypeRef's.
 - `netex_calendar` is properly flushed after import.
 
 ## [0.3.0] – 2024-09-18
+
 ### Added
+
 - Support for DatedServiceJourney.
 
 ### Fixed
+
 - Improved detection of changes in imported data.
 
 ### Changed
+
 - Imports now uses full NeTEx IDs in DB.
 - Refactored import mechanism to use ChristmasTreeParser. It's a
   service now.
 
 ## [0.2.0] – 2024-04-18
+
 ### Added
+
 - Route sets now have overall import status, and per day activation
   status.
 - Several new artisan commands to administer sets and activation.
 - Notices added both to DB and as API call.
 
 ### Changed
+
 - Route set related artisan commands have been renamed to a shared
   `netex:routedata-` prefix
 - Route sets are now provided by full path, not relative to disk. Use
   of Laravel disks has been refactored to use Flysystem directly.
 
 ### Fixed
+
 - Activation will not choke on duplicate journeys/calls in route set.
-- Increased length of name* related columns
+- Increased length of name\* related columns
 - Laravel 10.x composer requirement support
 
 ## [0.1.3] – 2023-01-16
 
 ### Added
+
 - Tariff Zones added and mapped with stop places. These include the
   defined geographic polygon as GML posList.
 - Topographic places benefited from the same import as above and now
   have the GML polygon area available.
 
 ### Changed
+
 - Supports Laravel 9.x
 
 ### Fixed
+
 - Stop place import now properly counts available elements before
   processing, giving a correct progress bar.
 
 ## [0.1.2] – 2022-06-30
 
 ### Added
+
 - Vehicle blocks extracted to separate table. Vehicle schedules are
   now a pivot table between `netex_vehicle_blocks` and
   `netex_vehicle_schedules`.
 - New `netex:status` artisan command.
 - Stop places now have an 'active' state, based on existence in
-  current route set.  Supplementary cli command
+  current route set. Supplementary cli command
   `netex:sync-active-stops` added, and this sync is done on both route
-  data and stop place uploads.  A new global global query scope is
+  data and stop place uploads. A new global global query scope is
   added, though not utilized, buta local `$stop->active()` scope is
   immediately available on stop models.
 
 ## [0.1.1] – 2022-04-06
 
 ### Added
+
 - Route data is now 'activated' in two tables w/models: ActiveJourneys
   and ActiveCalls. This speeds up the complexity and query time for
   typical route data lookups.
 
 ### Fixed
+
 - Route data import time is drastically reduced by using inserts in
   bulk instead of one-and-one insertion
 
 ## [0.1.0] 2021-11-16
 
 ### Added
+
 - DB migration for tables related to stop places.
 - Models with relations for all stop place related tables.
 - Artisan command 'netex:importstops' for parsing and importing stop

--- a/database/migrations/2025_02_07_100000_netex_line_public_code.php
+++ b/database/migrations/2025_02_07_100000_netex_line_public_code.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('netex_active_calls', function(Blueprint $table) {
+            $table->char('line_public_code')
+                ->comment('Publicly facing line number')
+                ->after('active_journey_id');
+            $table->dropColumn('line_private_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('netex_active_calls', function(Blueprint $table) {
+            $table->unsignedInteger('line_private_code')
+                ->comment('Internal numeric line number')
+                ->after('active_journey_id');
+            $table->dropColumn('line_public_code');
+        });
+    }
+};

--- a/src/Models/ActiveCall.php
+++ b/src/Models/ActiveCall.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @property string $id Unique ID of call for stop/journey/day/order
  * @property string $active_journey_id
- * @property int $line_private_code Internal numeric line number
+ * @property int $line_public_code Publicly facing line number
  * @property string $destination_display Interim/current destination. Often changed during a journey
  * @property int $order Order of call during journey
  * @property string $stop_quay_id Stop place quay ID
@@ -67,7 +67,7 @@ class ActiveCall extends Model
      */
     protected $fillable = [
         'active_journey_id',
-        'line_private_code',
+        'line_public_code',
         'destination_display',
         'order',
         'stop_quay_id',

--- a/src/Services/RouteActivator.php
+++ b/src/Services/RouteActivator.php
@@ -525,7 +525,7 @@ class RouteActivator extends RouteBase
             [
                 'id' => self::makeCallId($rawCall, $jRec['id']),
                 'active_journey_id' => $jRec['id'],
-                'line_private_code' => $jRec['line_private_code'],
+                'line_public_code' => $jRec['line_public_code'],
             ]
         ));
     }

--- a/src/Services/RouteSetDiffDetector.php
+++ b/src/Services/RouteSetDiffDetector.php
@@ -80,7 +80,7 @@ class RouteSetDiffDetector extends RouteBase
                 [
                     'id' => $callId,
                     'active_journey_id' => $jRec['id'],
-                    'line_private_code' => $jRec['line_private_code'],
+                    'line_public_code' => $jRec['line_public_code'],
                 ]
             );
 


### PR DESCRIPTION
NeTEx nordic profile states that Lines must have PublicCode set, but PrivateCode is optional.

This fixes this case by using public code in activate calls.