### PR TITLE
Add descriptive exception message for incomplete route data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added descriptive error message when route data is incomplete.
+
 ### Changed
 
 - Removed line ID as part of active journey and active call IDs.

--- a/src/Services/RouteActivator.php
+++ b/src/Services/RouteActivator.php
@@ -4,6 +4,7 @@ namespace TromsFylkestrafikk\Netex\Services;
 
 use Closure;
 use DateInterval;
+use Exception;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -493,6 +494,9 @@ class RouteActivator extends RouteBase
         }
         $first = $rawCalls->first();
         $last = $rawCalls->last();
+        if (!$first || !$last) {
+            throw new Exception("Routedata is incomplete. Possible reasons include missing stop places. Make sure all neccessary stop places for route set are imported.");
+        }
         $jRec['first_stop_quay_id'] = $first->stop_quay_id;
         $jRec['last_stop_quay_id'] = $last->stop_quay_id;
         $jRec['start_at'] = $first->departure_time;


### PR DESCRIPTION
This doesn't change anything. It just checks for existing values and reports error when no data is found.

An obvious cause for this error is when trying to activate route data where stop places doesn't exist in DB. This was the root of the problem, and this check doesn't test for this explicitly, but hints strongly about this being the cause.

The rationale is that stop places *need* to be present for route data to have any value. We cannot add route data without stop places. They will then point to nowhere. No names, no lngLat, just empty space. Void.

So there is nothing changed in the mechanism. I created this issue when trying to activate route data across county borders where stops were missing. Later, the missing stops was added, and activation doesn't fail anymore.

So really, there is not need for this issue other than pointing the user in the right direction about possible causes for choke.

![bilde](https://github.com/user-attachments/assets/084de7a3-1e15-4179-a517-8a19a27fea6b)
